### PR TITLE
🌱 Switch CI jobs to kcp's Prow

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.19"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  - name: pull-apiextensions-apiserver-lint
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/apiextensions-apiserver"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - lint
+
+  - name: pull-apiextensions-apiserver-verify
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/apiextensions-apiserver"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - verify-codegen


### PR DESCRIPTION
## Summary
This removes the configuration for openshift's CI system and instead adds a .prow.yaml for kcp's own Prow setup.

Fixes kcp-dev/infra#42